### PR TITLE
Fix bug in FixedPool when used with closures

### DIFF
--- a/src/FixedPool.php
+++ b/src/FixedPool.php
@@ -31,8 +31,6 @@ class FixedPool extends AbstractPool
 
     public function execute(Process $process)
     {
-        Utils::checkOverwriteRunMethod(get_class($process));
-
         if ($this->aliveCount() < $this->max && !$process->isStarted()) {
             $process->start();
         }


### PR DESCRIPTION
Do not check for override method in `FixedPool::execute()` as it's already taken care of by `Process::__construct()`.

Fixes #10 