### PR TITLE
FTOK() collisions

### DIFF
--- a/src/Cache/SharedMemory.php
+++ b/src/Cache/SharedMemory.php
@@ -65,8 +65,8 @@ class SharedMemory implements CacheInterface
                 throw new \RuntimeException("file is not exists and it can not be created. file: {$file}");
             }
         }
-        $key = ftok($file, 'a');
-        $this->shm = shm_attach($key, $this->size); //allocate shared memory
+        
+        $this->shm = shm_attach(fileinode($file), $this->size); //allocate shared memory
     }
 
     /**


### PR DESCRIPTION
ftok() can have collisions quite easily especially on systems with lots of files. Users of the shared memory class may want to specify a temporary file so that memory is only shared between specific groups of executing processes. Using a file's inode is a much better way to prevent collisions of this nature.